### PR TITLE
fix: update default version to convert to 2.2.0

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -32,7 +32,7 @@ if (!asyncapiFile) {
   program.help(); // This exits the process
 }
 if (!version) {
-  version = '2.1.0';
+  version = '2.2.0';
 }
 
 try {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: Update default version to convert to 2.2.0 - we missed about it in the latest release.