### PR TITLE
feat: add output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,16 @@ id: 'urn:com.asynapi.streetlights'
 ...
 ```
 
-Save the result in a file:
+Save the result in a file by stream:
 
 ```sh
 asyncapi-converter streetlights.yml > streetlights2.yml
+```
+
+Save the result in a file by `-o, --output` flag:
+
+```sh
+asyncapi-converter streetlights.yml -o streetlights2.yml
 ```
 
 ### As a package

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,16 @@ const red = text => `\x1b[31m${text}\x1b[0m`;
 
 let asyncapiFile;
 let version;
+let output;
+
+const parseArguments = (asyncAPIPath, v) => {
+  asyncapiFile = path.resolve(asyncAPIPath);
+  version = v;
+}
+
+const parseOutput = (filePath) => {
+  output = path.resolve(filePath);
+}
 
 const showErrorAndExit = err => {
   console.error(red('Something went wrong:'));
@@ -20,11 +30,9 @@ const showErrorAndExit = err => {
 program
   .version(packageInfo.version)
   .arguments('<document> [version]')
-  .action((asyncAPIPath, v) => {
-    asyncapiFile = path.resolve(asyncAPIPath);
-    version = v;
-  })
+  .action(parseArguments)
   .option('--id <id>', 'application id (defaults to a generated one)')
+  .option('-o, --output <outputFile>', 'file where to put the converted AsyncAPI document', parseOutput)
   .parse(process.argv);
 
 if (!asyncapiFile) {
@@ -46,7 +54,11 @@ try {
     converted = JSON.stringify(converted, undefined, 2);
   }
 
-  console.log(converted);
+  if (output) {
+    fs.writeFileSync(output, converted, 'utf-8');
+  } else {
+    console.log(converted);
+  }
 } catch (e) {
   showErrorAndExit(e);
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add `-o` flag as output where converted spec should be saved.
- Add info about new flag in Readme.md.

**Related issue(s)**
Resolves https://github.com/asyncapi/converter-js/issues/93