### PR TITLE
docs: remove info about convert options from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ const { convert } = require('@asyncapi/converter')
 
 try {
   const asyncapi = fs.readFileSync('streetlights.yml', 'utf-8')
-  console.log(convert(asyncapi, '2.0.0', {
-    id: 'urn:com.asyncapi.streetlights'
-  }));
+  console.log(convert(asyncapi, '2.0.0'));
 } catch (e) {
   console.error(e);
 }
@@ -86,12 +84,8 @@ import type { ConvertVersion, ConvertOptions } from '@asyncapi/converter';
 
 try {
   const toVersion: ConvertVersion = '2.0.0';
-  const options: ConvertOptions = {
-    id: 'urn:com.asyncapi.streetlights'
-  };
-
   const asyncapi = fs.readFileSync('streetlights.yml', 'utf-8')
-  console.log(convert(asyncapi, toVersion, options));
+  console.log(convert(asyncapi, toVersion));
 } catch (e) {
   console.error(e)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As we removed `id` option in `ConvertOptions` type (when we released 1.0.0), we didn't update the Readme. That PR fixes it.