### PR TITLE
fix: disclose limitation about parameter schema reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ try {
 
 > **NOTE**: This feature is still WIP, and is until the final release of `3.0.0`.
 
-Conversion to version `3.x.x` from `2.x.x` has several assumptions that should be know before converting:
+Conversion to version `3.x.x` from `2.x.x` has several assumptions that should be known before converting:
 
 - The input must be valid AsyncAPI document.
 - External references are not resolved and converted, they remain untouched, even if they are incorrect.
@@ -164,6 +164,35 @@ Conversion to version `3.x.x` from `2.x.x` has several assumptions that should b
 ## Known missing features
 
 * When converting from 1.x to 2.x, Streaming APIs (those using `stream` instead of `topics` or `events`) are converted correctly but information about framing type and delimiter is missing until a [protocolInfo](https://github.com/asyncapi/extensions-catalog/issues/1) for that purpose is created.
+* When converting from 2.x to 3.x, and `parameter.schema` is defined with a reference, it will NOT look into the schema reference and include any relevant keywords for the v3 parameter. It will just create an empty parameter but leave the schema in the components section as is.
+  ```yaml
+  # 2.x.x
+  channels:
+    "{myParameter}":
+      parameters: 
+        myParameter: 
+          schema: 
+            $ref: "#/components/schemas/mySchema"
+  components: 
+    schemas:
+      mySchema:
+        enum: ["test"]
+        default: "test"
+        examples: ["test"]
+
+  # 3.0.0
+  channels:
+    "{myParameter}":
+      parameters: 
+        myParameter: {}
+
+  components: 
+    schemas:
+      mySchema:
+        enum: ["test"]
+        default: "test"
+        examples: ["test"]
+  ```
 
 ## Development
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ export type ConvertV2ToV3Options = {
   useChannelIdExtension?: boolean;
   convertServerComponents?: boolean;
   convertChannelComponents?: boolean;
+  failOnParameterReference?: boolean;
 }
 export type ConvertOptions = {
   v2tov3?: ConvertV2ToV3Options;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,6 @@ export type ConvertV2ToV3Options = {
   useChannelIdExtension?: boolean;
   convertServerComponents?: boolean;
   convertChannelComponents?: boolean;
-  failOnParameterReference?: boolean;
 }
 export type ConvertOptions = {
   v2tov3?: ConvertV2ToV3Options;

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -394,7 +394,7 @@ function convertParameter(parameter: any): any {
   }
 
   if(parameter.schema?.$ref) {
-    console.warn('Could not convert parameter object because the `.schema` property was a reference.\nThis have to be changed manually if you want any of the properties included, it will be converted to a default parameter. The reference was ' + parameter.schema?.$ref);
+    console.warn('Could not convert parameter object because the `.schema` property was a reference.\nThis have to be changed manually if you want any of the properties included. For now your parameter is an empty object after conversion. The reference was ' + parameter.schema?.$ref);
   }
 
   const enumValues = parameter.schema?.enum ?? null;

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -393,11 +393,7 @@ function convertParameter(parameter: any, options: RequiredConvertV2ToV3Options)
   }
 
   if(parameter.schema?.$ref) {
-    const errorMessage = 'Could not convert parameter object because the `.schema` property was a reference. This have to be changed manually if you want any of the properties included. The reference was ' + parameter.schema?.$ref;
-    if(options.failOnParameterReference === true) {
-      throw new Error(errorMessage);
-    }
-    console.error(errorMessage);
+    console.error('Could not convert parameter object because the `.schema` property was a reference. This have to be changed manually if you want any of the properties included. The reference was ' + parameter.schema?.$ref);
   }
 
   const enumValues = parameter.schema?.enum ?? null;

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -409,13 +409,13 @@ function convertParameter(parameter: any, options: RequiredConvertV2ToV3Options)
   });
 
   //Return the new v3 parameter object
-  return Object.assign({...v2ParameterObjectExtensions},
-    enumValues === null ? null : {enum: enumValues},
-    defaultValues === null ? null : {default: defaultValues},
-    description === null ? null : {description},
-    examples === null ? null : {examples},
-    location === null ? null : {location}
-  );
+  return {...v2ParameterObjectExtensions,
+    ...(enumValues === null ? null : {enum: enumValues}),
+    ...(defaultValues === null ? null : {default: defaultValues}),
+    ...(description === null ? null : {description}),
+    ...(examples === null ? null : {examples}),
+    ...(location === null ? null : {location})
+  };
 }
 
 /**

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -391,6 +391,10 @@ function convertParameter(parameter: any): any {
     }
   }
 
+  if(parameter.schema?.$ref) {
+    console.error('Could not convert parameter object because the `.schema` property was a reference. This have to be changed manually if you want any of the properties included. The reference was ' + parameter.schema?.$ref);
+  }
+
   const enumValues = parameter.schema?.enum ?? null;
   const defaultValues = parameter.schema?.default ?? null;
   const description = parameter.description ?? parameter.schema?.description ?? null;

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -435,7 +435,7 @@ function reportUnsupportedParameterValues(schema: any) {
     const listOfProperties = excessProperties.map(([propertyName, property]) => {
       return `- schema.${propertyName} with value: ${JSON.stringify(property)} are no longer supported`
     })
-    console.warn(`Found properties in parameter schema that are no longer supported and will be ignored by the converter.\n${listOfProperties.join('\n')}`);
+    console.warn(`Found properties in parameter schema that are no longer supported. Conversion completes with empty parameter object.\n${listOfProperties.join('\n')}`);
   }
 }
 

--- a/test/input/2.6.0/for-3.0.0-with-mixed-parameters.yml
+++ b/test/input/2.6.0/for-3.0.0-with-mixed-parameters.yml
@@ -19,7 +19,14 @@ channels:
         $ref: '#/components/parameters/location'
       mixed:
         $ref: '#/components/parameters/mixed'
+      schemaRef:
+        schema: 
+          $ref: '#/components/schemas/schemaParameter'
 components:
+  schemas: 
+    schemaParameter:
+      type: string
+      enum: ["test"]
   parameters:
     enum:
       schema:

--- a/test/input/2.6.0/for-3.0.0-with-reference-parameter.yml
+++ b/test/input/2.6.0/for-3.0.0-with-reference-parameter.yml
@@ -1,0 +1,27 @@
+asyncapi: 2.6.0
+
+info:
+  title: AsyncAPI Sample App
+  version: 1.0.1
+
+channels:
+  'lightingMeasured/{parameter}':
+    parameters: 
+      parameter: 
+        schema: 
+          $ref: '#/components/schemas/sentAt'
+    publish:
+      operationId: lightMeasured
+      message:
+        payload:
+          type: object
+          properties:
+            someProperty:
+              type: string
+
+components:
+  schemas:
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.

--- a/test/input/2.6.0/for-3.0.0-with-reference-parameter.yml
+++ b/test/input/2.6.0/for-3.0.0-with-reference-parameter.yml
@@ -5,11 +5,14 @@ info:
   version: 1.0.1
 
 channels:
-  'lightingMeasured/{parameter}':
+  'lightingMeasured/{parameter}/{parameter2}':
     parameters: 
       parameter: 
         schema: 
           $ref: '#/components/schemas/sentAt'
+      parameter2:
+        schema:
+          pattern: test
     publish:
       operationId: lightMeasured
       message:

--- a/test/output/3.0.0/from-2.6.0-with-mixed-parameters.yml
+++ b/test/output/3.0.0/from-2.6.0-with-mixed-parameters.yml
@@ -19,7 +19,12 @@ channels:
         $ref: '#/components/parameters/location'
       mixed:
         $ref: '#/components/parameters/mixed'
+      schemaRef: {}
 components:
+  schemas: 
+    schemaParameter:
+      type: string
+      enum: ["test"]
   parameters:
     enum:
       enum: ["test"]

--- a/test/output/3.0.0/from-2.6.0-with-reference-parameter.yml
+++ b/test/output/3.0.0/from-2.6.0-with-reference-parameter.yml
@@ -3,8 +3,8 @@ info:
   title: AsyncAPI Sample App
   version: 1.0.1
 channels:
-  'lightingMeasured/{parameter}':
-    address: 'lightingMeasured/{parameter}'
+  'lightingMeasured/{parameter}/{parameter2}':
+    address: 'lightingMeasured/{parameter}/{parameter2}'
     messages:
       lightMeasured.message:
         payload:
@@ -14,14 +14,15 @@ channels:
               type: string
     parameters:
       parameter: {}
+      parameter2: {}
 operations:
   lightMeasured:
     action: receive
     channel:
-      $ref: '#/channels/lightingMeasured~1{parameter}'
+      $ref: '#/channels/lightingMeasured~1{parameter}~1{parameter2}'
     messages:
       - $ref: >-
-          #/channels/lightingMeasured~1{parameter}/messages/lightMeasured.message
+          #/channels/lightingMeasured~1{parameter}~1{parameter2}/messages/lightMeasured.message
 components:
   schemas:
     sentAt:

--- a/test/output/3.0.0/from-2.6.0-with-reference-parameter.yml
+++ b/test/output/3.0.0/from-2.6.0-with-reference-parameter.yml
@@ -1,0 +1,30 @@
+asyncapi: 3.0.0
+info:
+  title: AsyncAPI Sample App
+  version: 1.0.1
+channels:
+  'lightingMeasured/{parameter}':
+    address: 'lightingMeasured/{parameter}'
+    messages:
+      lightMeasured.message:
+        payload:
+          type: object
+          properties:
+            someProperty:
+              type: string
+    parameters:
+      parameter: {}
+operations:
+  lightMeasured:
+    action: receive
+    channel:
+      $ref: '#/channels/lightingMeasured~1{parameter}'
+    messages:
+      - $ref: >-
+          #/channels/lightingMeasured~1{parameter}/messages/lightMeasured.message
+components:
+  schemas:
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.

--- a/test/second-to-third-version.spec.ts
+++ b/test/second-to-third-version.spec.ts
@@ -32,4 +32,16 @@ describe('convert() - 2.X.X to 3.X.X versions', () => {
     const result = convert(input, '3.0.0');
     assertResults(output, result);
   });
+
+  it('should throw exception when parameter encountered with failOnParameterReference=true', () => {
+    const input = fs.readFileSync(path.resolve(__dirname, 'input', '2.6.0', 'for-3.0.0-with-reference-parameter.yml'), 'utf8');
+    expect(() => {convert(input, '3.0.0', {v2tov3: {failOnParameterReference: true}})}).toThrowError('Could not convert parameter object because the `.schema` property was a reference. This have to be changed manually if you want any of the properties included. The reference was #/components/schemas/sentAt');
+  });
+
+  it('should handle parameter object', () => {
+    const input = fs.readFileSync(path.resolve(__dirname, 'input', '2.6.0', 'for-3.0.0-with-reference-parameter.yml'), 'utf8');
+    const output = fs.readFileSync(path.resolve(__dirname, 'output', '3.0.0', 'from-2.6.0-with-reference-parameter.yml'), 'utf8');
+    const result = convert(input, '3.0.0', {v2tov3: {failOnParameterReference: false}});
+    assertResults(output, result);
+  });
 });

--- a/test/second-to-third-version.spec.ts
+++ b/test/second-to-third-version.spec.ts
@@ -33,15 +33,10 @@ describe('convert() - 2.X.X to 3.X.X versions', () => {
     assertResults(output, result);
   });
 
-  it('should throw exception when parameter encountered with failOnParameterReference=true', () => {
-    const input = fs.readFileSync(path.resolve(__dirname, 'input', '2.6.0', 'for-3.0.0-with-reference-parameter.yml'), 'utf8');
-    expect(() => {convert(input, '3.0.0', {v2tov3: {failOnParameterReference: true}})}).toThrowError('Could not convert parameter object because the `.schema` property was a reference. This have to be changed manually if you want any of the properties included. The reference was #/components/schemas/sentAt');
-  });
-
   it('should handle parameter object', () => {
     const input = fs.readFileSync(path.resolve(__dirname, 'input', '2.6.0', 'for-3.0.0-with-reference-parameter.yml'), 'utf8');
     const output = fs.readFileSync(path.resolve(__dirname, 'output', '3.0.0', 'from-2.6.0-with-reference-parameter.yml'), 'utf8');
-    const result = convert(input, '3.0.0', {v2tov3: {failOnParameterReference: false}});
+    const result = convert(input, '3.0.0');
     assertResults(output, result);
   });
 });


### PR DESCRIPTION
**Description**
If a parameter's schema is defined with a reference in v2, it would completely be removed in v3, because we cant manipulate references correctly yet, see https://github.com/asyncapi/converter-js/issues/90