### PR TITLE
feat: remove messageId when converting to 3.0.0

### DIFF
--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -325,6 +325,7 @@ function convertMessages(data: ConvertMessagesObjectData): Record<string, any>{
   const messages = {...data.messages};
   // Convert schema formats to union schemas
   Object.entries(messages).forEach(([_, message]) => {
+    delete message.messageId;
     if(message.schemaFormat !== undefined) {
       const payloadSchema = message.payload;
       message.payload = {

--- a/test/output/3.0.0/from-2.6.0-with-deep-local-references.yml
+++ b/test/output/3.0.0/from-2.6.0-with-deep-local-references.yml
@@ -23,7 +23,6 @@ channels:
       subscribe.message.0:
         $ref: '#/components/messages/turnOnOff'
       customMessageId:
-        messageId: customMessageId
         payload:
           type: object
           properties:
@@ -61,7 +60,6 @@ components:
         subscribe.message.0:
           $ref: '#/components/messages/turnOnOff'
         customMessageId:
-          messageId: customMessageId
           payload:
             type: object
             properties:

--- a/test/output/3.0.0/from-2.6.0-with-servers-and-channels-components.yml
+++ b/test/output/3.0.0/from-2.6.0-with-servers-and-channels-components.yml
@@ -94,7 +94,6 @@ components:
         subscribe.message.0:
           $ref: '#/components/messages/turnOnOff'
         customMessageId:
-          messageId: customMessageId
           payload:
             type: object
         subscribe.message.2:

--- a/test/output/3.0.0/from-2.6.0.yml
+++ b/test/output/3.0.0/from-2.6.0.yml
@@ -96,7 +96,6 @@ channels:
       subscribe.message.0:
         $ref: '#/components/messages/turnOnOff'
       customMessageId:
-        messageId: customMessageId
         payload:
           type: object
       subscribe.message.2:


### PR DESCRIPTION
**Description**

Removes the `messageId` property from the Message objects.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/978