### PR TITLE
fix: operation messages references should point to channels

### DIFF
--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -271,7 +271,6 @@ function convertOperationObject(data: ConvertOperationObjectData, options: Requi
     applyMessageRefsToOperation(serializedMessages, newMessagePath, operation);
   }
 
-
   const sortedOperation = sortObjectKeys(
     operation, 
     ['action', 'channel', 'title', 'summary', 'description', 'security', 'tags', 'externalDocs', 'bindings', 'traits'],

--- a/src/third-version.ts
+++ b/src/third-version.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, createRefObject, isRefObject, sortObjectKeys, getValueByRef, getValueByPath, createRefPath } from './utils';
+import { isPlainObject, createRefObject, isRefObject, sortObjectKeys, getValueByRef, getValueByPath, createRefPath, isRemoteRef } from './utils';
 import type { AsyncAPIDocument, ConvertOptions, ConvertV2ToV3Options, ConvertFunction } from './interfaces';
 
 export const converters: Record<string, ConvertFunction> = {
@@ -111,6 +111,7 @@ type ToStandaloneOperationData = {
   options: any, 
   oldPath: string[]
 }
+
 /**
  * Convert operation part of channels into standalone operations
  */
@@ -270,6 +271,7 @@ function convertOperationObject(data: ConvertOperationObjectData, options: Requi
     applyMessageRefsToOperation(serializedMessages, newMessagePath, operation);
   }
 
+
   const sortedOperation = sortObjectKeys(
     operation, 
     ['action', 'channel', 'title', 'summary', 'description', 'security', 'tags', 'externalDocs', 'bindings', 'traits'],
@@ -304,7 +306,7 @@ function applyMessageRefsToOperation(serializedMessages: Record<string, any>, ne
   if (Object.keys(serializedMessages ?? {}).length > 0 ) {
     const newOperationMessages: Array<any> = [];
     Object.entries(serializedMessages).forEach(([messageId, messageValue]) => {
-      if (isRefObject(messageValue)) {
+      if (isRemoteRef(messageValue)) {
         // shallow copy of JS reference
         newOperationMessages.push({ ...messageValue });
       } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,6 +70,10 @@ export function isRefObject(value: unknown): boolean {
   return Boolean(value && '$ref' in (value as { $ref: any }));
 }
 
+export function isRemoteRef(value: any): boolean {
+  return isRefObject(value) && !value.$ref.startsWith('#')
+}
+
 export function getValueByRef(root: any, ref: string) {
   if (!ref.startsWith('#')) {
     return;

--- a/test/input/2.6.0/for-3.0.0-with-deep-local-references.yml
+++ b/test/input/2.6.0/for-3.0.0-with-deep-local-references.yml
@@ -19,7 +19,7 @@ channels:
   'turnOn':
     publish:
       message:
-        $ref: '#/components/messages/lightMeasured'
+        $ref: '#/components/messages/turnOnOff'
     subscribe:
       message:
         oneOf:
@@ -38,7 +38,7 @@ components:
     'someChannel':
       publish:
         message:
-          $ref: '#/components/messages/lightMeasured'
+          $ref: '#/components/messages/turnOnOff'
       subscribe:
         message:
           oneOf:

--- a/test/output/3.0.0/from-2.6.0-with-deep-local-references.yml
+++ b/test/output/3.0.0/from-2.6.0-with-deep-local-references.yml
@@ -19,7 +19,7 @@ channels:
     address: turnOn
     messages:
       publish.message:
-        $ref: '#/components/messages/lightMeasured'
+        $ref: '#/components/messages/turnOnOff'
       subscribe.message.0:
         $ref: '#/components/messages/turnOnOff'
       customMessageId:
@@ -42,13 +42,13 @@ operations:
     channel:
       $ref: '#/channels/turnOn'
     messages:
-      - $ref: '#/components/messages/lightMeasured'
+      - $ref: '#/channels/turnOn/messages/publish.message'
   turnOn.subscribe:
     action: send
     channel:
       $ref: '#/channels/turnOn'
     messages:
-      - $ref: '#/components/messages/turnOnOff'
+      - $ref: '#/channels/turnOn/messages/subscribe.message.0'
       - $ref: '#/channels/turnOn/messages/customMessageId'
 components:
   channels:
@@ -56,7 +56,7 @@ components:
       address: someChannel
       messages:
         publish.message:
-          $ref: '#/components/messages/lightMeasured'
+          $ref: '#/components/messages/turnOnOff'
         subscribe.message.0:
           $ref: '#/components/messages/turnOnOff'
         customMessageId:
@@ -98,11 +98,11 @@ components:
       channel:
         $ref: '#/components/channels/someChannel'
       messages:
-        - $ref: '#/components/messages/lightMeasured'
+        - $ref: '#/components/channels/someChannel/messages/publish.message'
     someChannel.subscribe:
       action: send
       channel:
         $ref: '#/components/channels/someChannel'
       messages:
-        - $ref: '#/components/messages/turnOnOff'
+        - $ref: '#/components/channels/someChannel/messages/subscribe.message.0'
         - $ref: '#/components/channels/someChannel/messages/customMessageId'

--- a/test/output/3.0.0/from-2.6.0-with-servers-and-channels-components.yml
+++ b/test/output/3.0.0/from-2.6.0-with-servers-and-channels-components.yml
@@ -157,13 +157,13 @@ components:
       channel:
         $ref: '#/components/channels/usedChannel'
       messages:
-        - $ref: '#/components/messages/lightMeasured'
+        - $ref: '#/components/channels/usedChannel/messages/publish.message'
     usedChannel.subscribe:
       action: send
       channel:
         $ref: '#/components/channels/usedChannel'
       messages:
-        - $ref: '#/components/messages/turnOnOff'
+        - $ref: '#/components/channels/usedChannel/messages/subscribe.message.0'
         - $ref: '#/components/channels/usedChannel/messages/customMessageId'
         - $ref: '#/components/channels/usedChannel/messages/subscribe.message.2'
         - $ref: 'https://example.com/message'
@@ -182,4 +182,4 @@ components:
           scopes:
             - 'write:pets'
       messages:
-        - $ref: '#/components/messages/dimLight'
+        - $ref: '#/components/channels/unusedChannel/messages/dimLight.message'

--- a/test/output/3.0.0/from-2.6.0.yml
+++ b/test/output/3.0.0/from-2.6.0.yml
@@ -141,14 +141,16 @@ operations:
       $ref: >-
         #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1turn~1on
     messages:
-      - $ref: '#/components/messages/lightMeasured'
+      - $ref: >-
+          #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1turn~1on/messages/publish.message
   'smartylighting/streetlights/1/0/action/{streetlightId}/turn/on.subscribe':
     action: send
     channel:
       $ref: >-
         #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1turn~1on
     messages:
-      - $ref: '#/components/messages/turnOnOff'
+      - $ref: >-
+          #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1turn~1on/messages/subscribe.message.0
       - $ref: >-
           #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1turn~1on/messages/customMessageId
       - $ref: >-
@@ -159,7 +161,7 @@ operations:
     channel:
       $ref: '#/channels/customChannelId'
     messages:
-      - $ref: '#/components/messages/turnOnOff'
+      - $ref: '#/channels/customChannelId/messages/turnOnOff.message'
   dimLight:
     action: send
     channel:
@@ -176,7 +178,8 @@ operations:
         scopes:
           - 'write:pets'
     messages:
-      - $ref: '#/components/messages/dimLight'
+      - $ref: >-
+          #/channels/smartylighting~1streetlights~11~10~1action~1{streetlightId}~1dim/messages/dimLight.message
 components:
   messages:
     lightMeasured:


### PR DESCRIPTION
**Description**
This PR fixes that operation references in `messages` MUST point to channel messages.